### PR TITLE
Add zeek-format-before-save; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This is a very basic Emacs major mode for Zeek scripts. Supported features:
 
 - Script formatting and parsing via [zeekscript](https://github.com/zeek/zeekscript),
   when available: `C-c C-f` formats the current buffer; `C-c C-p` parses it and renders
-  the parse tree into a new buffer.
+  the parse tree into a new buffer. It also provides `zeek-format-before-save`, which
+  can be used in a hook to format Zeek buffers before saving them.
 
 - Whitespace configuration: `TAB` always inserts tab character. The mode also highlights
   trailing whitespace as well as spaces used after tabs.
@@ -19,3 +20,9 @@ formatting approximates it.
 Place `zeek-mode.el` in a directory accessible to Emacs and source it as follows:
 
     (require 'zeek-mode)
+
+If you'd like your file to be automatically formatted before saving, also add
+
+    (add-hook 'before-save-hook #'zeek-format-before-save)
+
+After requiring `'zeek-mode`.

--- a/zeek-mode.el
+++ b/zeek-mode.el
@@ -147,6 +147,12 @@ reflected in the parse tree."
     (interactive)
     (zeek-command-on-buffer (zeek-script-cmd "parse" "-") "*zeek-script parse tree*"))
 
+  (defun zeek-format-before-save ()
+    "Add this to .emacs to run zeek-format on the current buffer when saving:
+\(add-hook 'before-save-hook #'zeek-format-before-save)"
+    (interactive)
+    (when (eq major-mode 'zeek-mode) (zeek-format-buffer)))
+
   (add-hook 'zeek-mode-hook
             (lambda ()
               (local-set-key (kbd "C-c C-f") 'zeek-format-buffer)


### PR DESCRIPTION
This adds a function that can be used as a hook to automatically format zeek files before saving the buffer to disk. 