### PR TITLE
Avoid leaving stale error buffer around when running commands

### DIFF
--- a/zeek-mode.el
+++ b/zeek-mode.el
@@ -100,6 +100,9 @@ to the echo area. By default the buffer is temporary and killed
 upon return, but the keep-errbuf argument, when t, preserves it."
     (let ((errbuf "*zeek-script errors*"))
 
+      (when (get-buffer errbuf)
+        (kill-buffer errbuf))
+
       ;; Run the given command on the buffer, plugging in stdout and stderr
       ;; destination buffers.
       (shell-command-on-region (point-min) (point-max)


### PR DESCRIPTION
This could lead to error messages from earlier calls popping up in the echo
area, despite successful execution of zeek-command-on-buffer.