### PR TITLE
Fix coloring of directives with quotation marks

### DIFF
--- a/zeek-mode.el
+++ b/zeek-mode.el
@@ -22,7 +22,7 @@
 ;; ---- Syntax Highlighting --------------------------------------------
 
 (defvar zeek-mode-keywords
-  `(("\\(@[^#\n]+\\)" (0 font-lock-doc-face))
+  `(("\\(@[^#\n]+\\)" (0 font-lock-doc-face t))
     (,(concat "\\<"
 	      (regexp-opt '("const" "option" "redef") t)
 	      "\\>") (0 font-lock-constant-face))


### PR DESCRIPTION
Font-lock can highlight via syntactical constructs (e.g. string constants) and keywords (e.g. Zeek's reserved words). On directives like

    @if ( getenv("FOO") = "" )

these collide, because the syntactical highlighting of strings kicks in first and "wins", meaning the whole construct then gets colored incorrectly.

This makes the keyword rule for directives state that it wants to override existing coloring.